### PR TITLE
Using overrides from NPM to enforce patched version of minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,16 +51,20 @@
       "android"
     ]
   },
+  "overrides": {
+    "recursive-readdir@^2.2.2": {
+      "minimatch": "3.0.5"
+    }
+  },
   "dependencies": {
     "brace-expansion": "^2.0.1",
     "concat-map": "^0.0.1",
     "html5shiv": "^3.7.3",
     "jquery": "^3.6.0",
-    "minimatch": "^3.0.5",
-    "onesignal-cordova-plugin": "3.0.0-beta1",
     "recursive-readdir": "^2.2.2",
     "respond.js": "^1.4.2",
     "swiper": "^6.8.4",
-    "tether": "^2.0.0"
+    "tether": "^2.0.0",
+    "onesignal-cordova-plugin": "3.0.2"
   }
 }

--- a/plugins/cordova-plugin-androidx-adapter/package.json
+++ b/plugins/cordova-plugin-androidx-adapter/package.json
@@ -37,6 +37,11 @@
     "q": "^1.5.1",
     "recursive-readdir": "^2.2.2"
   },
+  "overrides": {
+    "recursive-readdir@^2.2.2": {
+      "minimatch": "3.0.5"
+    }
+  },
   "deprecated": false,
   "description": "Cordova/Phonegap plugin to migrate any code which references the legacy Android Support Library to the new AndroidX mappings in a Cordova Android platform project.",
   "homepage": "https://github.com/dpa99c/cordova-plugin-androidx-adapter#readme",


### PR DESCRIPTION
Please note that, where required, package-lock.json and node_modules have been removed. This is to remind you to do so :) because of the NPM bug https://github.com/npm/cli/issues/4232

So, something like this, assuming you are in the root folder
```
rm package-lock.json; \
rm -rf node_modules; \
rm plugins/cordova-plugin-androidx-adapter/package-lock.json; \
rm -rf plugins/cordova-plugin-androidx-adapter/node_modules; \
npm install
```
After, you can run meterian :)

The relevant changes are in the /package.json and in plugins/cordova-plugin-androidx-adapter/package.json, where these lines were added to enforce the override:
```
  "overrides": {
    "recursive-readdir@^2.2.2": {
      "minimatch": "3.0.5"
    }
  },
```
You should get a clean report like this one:
https://www.meterian.com/projects/?pid=2e771dab-eee6-443c-83e8-e281b8040ba6&branch=main

The override mechanism is explained here:
https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides
